### PR TITLE
Adjust AppIdentity.App.new/1 and App typespecs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ ts/docs/
 tmp/
 work/
 app-identity-suite-*.json
+.elixir-version
+.ruby-version
+.erlang-version

--- a/elixir/test/app_identity_app_test.exs
+++ b/elixir/test/app_identity_app_test.exs
@@ -34,4 +34,16 @@ defmodule AppIdentityAppTest do
     assert {:error, "config must be nil or a map"} =
              App.new(%{id: 1, secret: "a", version: 1, config: 3})
   end
+
+  test "construction from a wrapped value" do
+    assert {:ok, %App{}} = App.new({:ok, %{id: 1, secret: "a", version: 1}})
+  end
+
+  test "construction from a loader function, successful" do
+    assert {:ok, %App{}} = App.new(fn -> {:ok, %{id: 1, secret: "a", version: 1}} end)
+  end
+
+  test "construction from a loader function, unsuccessful" do
+    assert {:error, "app can only be created from a map or struct"} = App.new(fn -> nil end)
+  end
 end


### PR DESCRIPTION
## Release Notes

The implementation of the standard AppIdentity.Plug differs from the initial implementation used by Kinetic's internal implementation and requires some redevelopment (this is planned and expected).

During this redevelopment, we determined that the specification for an app finder (`t:AppIdentity.App.finder/0`) does not match the possible return values from a Ecto `Repo.get/3` operation (`struct | nil`) or a `fetch/2`-like operation (`{:ok | :error, any()} | :error`). AppIdentity.App.new/1 handled most cases correctly (anything except a valid `input` value resulted in `{:error, String.t()}`), requiring only the addition of function heads that handle `{:ok, input}` values.

Tests have been added that verify this.

Signed-off-by: Austin Ziegler <aziegler@kineticcommerce.com>