### PR TITLE
Fix CI Builds

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -19,22 +19,28 @@ jobs:
         include:
           - elixir: '1.10'
             otp: '21'
+            os: ubuntu-20.04
           - elixir: '1.11'
             otp: '21'
+            os: ubuntu-20.04
           - elixir: '1.11'
             otp: '23'
+            os: ubuntu-20.04
           - elixir: '1.12'
             otp: '24'
+            os: ubuntu-22.04
           - elixir: '1.13'
             otp: '24'
+            os: ubuntu-22.04
+          - elixir: '1.14'
+            otp: '25'
+            os: ubuntu-22.04
             check_formatted: true
             warnings_as_errors: true
             dialyzer: true
             credo: true
-          - elixir: '1.14' # latest version
-            otp: '25'
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-22.04
         node:
           - 16
         pnpm:
@@ -25,9 +25,9 @@ jobs:
         ruby:
           - '3.1'
         elixir:
-          - '1.13'
+          - '1.14'
         otp:
-          - '24'
+          - '25'
 
     runs-on: ${{ matrix.os }}
 

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -5,4 +5,10 @@
 
 source "https://rubygems.org/"
 
+# As of 2022-12-15, Psych 5.0 does not install on macOS Ventura. Lock to the
+# latest known working version.
+install_if -> { RUBY_PLATFORM =~ /darwin/ } do
+  gem "psych", "~> 4.0"
+end
+
 gemspec

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -16,6 +16,32 @@ Hoe.spec "app_identity" do
   self.history_file = "Changelog.md"
   self.readme_file = "README.md"
 
+  # This is a hack because of an issue with Hoe 3.26, but I'm not sure which
+  # hoe version introduced this issue or if it's a JRuby issue. This issue is
+  # demonstrable in lib/hoe.rb at line 676, which is (reformatted for space):
+  #
+  # ```ruby
+  # readme =
+  #   input
+  #     .lines
+  #     .chunk { |l| l[/^(?:=+|#+)/] || "" } # # chunk is different somehow
+  #     .map(&:last) # <-- HERE: "#" does not respond to #last
+  #     .each_slice(2)
+  #     .map { |k, v|
+  #       kp = k.join
+  #       kp = kp.strip.chomp(":").split.last.downcase if k.size == 1
+  #       [kp, v.join.strip]
+  #     }
+  #     .to_h
+  # ```
+  #
+  # We don't *ship* with JRuby, but use it in CI only, so this is here at least
+  # temporarily.
+  if RUBY_PLATFORM.match?(/java/)
+    self.summary = self.description = "Description for testing"
+    self.homepage = "https://github.com/KineticCafe/app-identity/tree/main/ruby/"
+  end
+
   license "MIT"
 
   spec_extras[:metadata] = ->(val) { val["rubygems_mfa_required"] = "true" }

--- a/ruby/support/app_identity/support.rb
+++ b/ruby/support/app_identity/support.rb
@@ -89,7 +89,7 @@ module AppIdentity::Support # :nodoc:
     nonce = opts.delete(:nonce) { "nonce" }
     version = opts.delete(:version) { 1 }
 
-    proof = version == 1 ? "#{app_id}:#{nonce}:#{padlock}" : "#{version}:#{app_id}:#{nonce}:#{padlock}"
+    proof = (version == 1) ? "#{app_id}:#{nonce}:#{padlock}" : "#{version}:#{app_id}:#{nonce}:#{padlock}"
 
     Base64.urlsafe_encode64(proof)
   end


### PR DESCRIPTION
## Fix Elixir CI Builds

### Technical Change Notes

On GitHub Actions, `ubuntu-latest` shifted from `ubuntu-20.04` to `ubuntu-22.04`, which caused older versions of Elixir to break. This causes all PRs to fail, so instead of using `ubuntu-latest` we will *only* use explicit OS versions.

## Fix Ruby CI builds

### Technical Change Notes

- As a `Gemfile.lock` is not committed for the gem, occasionally things like `standardrb` update and change defaults. This is one of those times. Reformatted `ruby/support/app_identity/support.rb` to fix this issue.

- There is an issue with Psych 5.0 and macOS installations, so I could not properly simulate the CI environment without locking the Psych gem to 4.x.

- Fixed a bad interaction between Hoe 3.26 and JRuby. I'm not sure where the issue lies, because JRuby versioning doesn't provide any indication of what level of Ruby language support is present, but I will be reporting an issue to both seattlerb/hoe and jruby/jruby.