### PR TITLE
Update compatibility table in spec (minor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,9 @@ App Identity is _not_:
   secure for user authentication, and would require undefined side channels to
   communicate the shared secrets.
 
-App Identity algorithm versions are strictly upgradeable. That is, a version
-1 app can verify version 1, 2, 3, or 4 proofs. However, a version 2 app will
-_never_ validate a version 1 proof.
-
-| App Version | `1` | `2` | `3` | `4` |
-| ----------- | --- | --- | --- | --- |
-| `1`         | ✅  | ✅  | ✅  | ✅  |
-| `2`         | ⛔️ | ✅  | ✅  | ✅  |
-| `3`         | ⛔️ | ⛔️ | ✅  | ✅  |
-| `4`         | ⛔️ | ⛔️ | ⛔️ | ✅  |
+App Identity algorithm versions are strictly upgradeable. See
+[Algorithm Versions](spec/README.md#algorithm-versions) in the specification
+for details.
 
 ### Indications and Contraindications
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -79,18 +79,18 @@ a version 1 app can verify version 1, 2, 3, or 4 proofs. However, a version
 <table>
   <thead>
     <tr>
-      <th rowspan=2>Version</th>
+      <th rowspan=2>App Identity<br />Version</th>
       <th rowspan=2>Nonce</th>
       <th rowspan=2>Digest Algorithm</th>
-      <th colspan=4>Can Verify</th>
+      <th colspan=4>Can Verify Proof<br />from Version</th>
     </tr>
     <tr><th>1</th><th>2</th><th>3</th><th>4</th></tr>
   </thead>
   <tbody>
-    <tr><th>1</th><td>random</td><td>SHA 256</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td></tr>
-    <tr><th>2</th><td>timestamp ± fuzz</td><td>SHA 256</td><td>⛔️</td><td>✅</td><td>✅</td><td>✅</td></tr>
-    <tr><th>3</th><td>timestamp ± fuzz</td><td>SHA 384</td><td>⛔️</td><td>⛔️</td><td>✅</td><td>✅</td></tr>
-    <tr><th>4</th><td>timestamp ± fuzz</td><td>SHA 512</td><td>⛔️</td><td>⛔️</td><td>⛔️</td><td>✅</td></tr>
+    <tr><th>1</th><td>random</td><td>SHA 256</td><td align="center"> Yes </td><td align="center"> Yes </td><td align="center"> Yes </td><td align="center"> Yes </td></tr>
+    <tr><th>2</th><td>timestamp ± fuzz</td><td>SHA 256</td><td align="center"> - </td><td align="center"> Yes </td><td align="center"> Yes </td><td align="center"> Yes </td></tr>
+    <tr><th>3</th><td>timestamp ± fuzz</td><td>SHA 384</td><td align="center"> - </td><td align="center"> - </td><td align="center"> Yes </td><td align="center"> Yes </td></tr>
+    <tr><th>4</th><td>timestamp ± fuzz</td><td>SHA 512</td><td align="center"> - </td><td align="center"> - </td><td align="center"> - </td><td align="center"> Yes </td></tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Technical change notes
======================

This changes the wording in the header of the compatibility table in the spec, and uses less colourful checkmarks.

A similar table was removed from the top level README and a reference to the appropriate section in the spec put in its place.