### PR TITLE
Fix `app_identity` for releases

### DIFF
--- a/elixir/Changelog.md
+++ b/elixir/Changelog.md
@@ -1,6 +1,14 @@
 # App Identity for Elixir Changelog
 
-## 1.3.0 / 2023-07-20
+## 1.3.1 / 2023-07-20
+
+- Packages released to hex.pm by default include the `priv/` directory, but
+  nothing is done to ensure that those packages include anything other than the
+  literal files. The `priv/` directory contained two symbolic links
+  (`optional.json` and `required.json`) which were symlinks to the project
+  integration suite generators, only used in integration testing.
+
+## 1.3.0 / 2023-07-19
 
 - Rename all spec uses of `String.t()` to `binary()` as
 

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -4,7 +4,7 @@ defmodule AppIdentity.MixProject do
   def project do
     [
       app: :app_identity,
-      version: "1.3.0",
+      version: "1.3.1",
       description: "Fast, lightweight, cryptographically secure app authentication",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
@@ -28,6 +28,7 @@ defmodule AppIdentity.MixProject do
         ]
       ],
       package: [
+        files: ~w(lib .formatter.exs mix.exs *.md),
         licenses: ["Apache-2.0"],
         links: %{
           "Project" => "https://github.com/KineticCafe/app_identity",

--- a/elixir/priv/optional.json
+++ b/elixir/priv/optional.json
@@ -1,1 +1,0 @@
-../../integration/optional.json

--- a/elixir/priv/required.json
+++ b/elixir/priv/required.json
@@ -1,1 +1,0 @@
-../../integration/required.json

--- a/elixir/support/app_identity/suite/generator.ex
+++ b/elixir/support/app_identity/suite/generator.ex
@@ -103,18 +103,17 @@ defmodule AppIdentity.Suite.Generator do
     end
   end
 
-  @priv_dir List.to_string(:code.priv_dir(:app_identity))
-
-  @required_test_file Path.join(@priv_dir, "required.json")
-  @optional_test_file Path.join(@priv_dir, "optional.json")
+  @file_path Path.dirname(__ENV__.file)
+  @required_file Path.join(@file_path, "required.json")
+  @optional_file Path.join(@file_path, "optional.json")
 
   @tests %{
-    required: Jason.decode!(File.read!(@required_test_file)),
-    optional: Jason.decode!(File.read!(@optional_test_file))
+    required: Jason.decode!(File.read!(@required_file)),
+    optional: Jason.decode!(File.read!(@optional_file))
   }
 
-  @external_resource @required_test_file
-  @external_resource @optional_test_file
+  @external_resource @required_file
+  @external_resource @optional_file
 
   defp generate_suite do
     %{

--- a/elixir/support/app_identity/suite/optional.json
+++ b/elixir/support/app_identity/suite/optional.json
@@ -1,0 +1,1 @@
+../../../../integration/optional.json

--- a/elixir/support/app_identity/suite/required.json
+++ b/elixir/support/app_identity/suite/required.json
@@ -1,0 +1,1 @@
+../../../../integration/required.json


### PR DESCRIPTION
Packages released to hex.pm by default include the `priv/` directory, but nothing is done to ensure that those packages include anything other than the literal files. The `priv/` directory contained two symbolic links (`optional.json` and `required.json`) which were symlinks to the project integration suite generators, only used in integration testing.