### PR TITLE
Elixir: Padlock verification is case-insensitive

### DIFF
--- a/elixir/Changelog.md
+++ b/elixir/Changelog.md
@@ -1,5 +1,11 @@
 # App Identity for Elixir Changelog
 
+## 1.3.2 / 2023-09-05
+
+- Resolved an issue where padlock values sent using lowercase hex values were
+  not comparing properly. Added tests for the case as well as an additional
+  validation doctest.
+
 ## 1.3.1 / 2023-07-20
 
 - Packages released to hex.pm by default include the `priv/` directory, but
@@ -10,7 +16,8 @@
 
 ## 1.3.0 / 2023-07-19
 
-- Rename all spec uses of `String.t()` to `binary()` as
+- Rename many spec uses of `String.t()` to `binary()` as we do not necessarily
+  require UTF-8.
 
 - Extensive reorganization of the `AppIdentity.Plug` documentation to improve
   the readability of the configuration.

--- a/elixir/lib/app_identity/validation.ex
+++ b/elixir/lib/app_identity/validation.ex
@@ -48,6 +48,12 @@ defmodule AppIdentity.Validation do
       iex> AppIdentity.Validation.validate(:padlock, "")
       {:error, "padlock must not be an empty string"}
 
+      iex> AppIdentity.Validation.validate(:padlock, "zzz")
+      {:error, "padlock must be a hex string value"}
+
+      iex> AppIdentity.Validation.validate(:padlock, "fff")
+      {:ok, "FFF"}
+
       iex> AppIdentity.Validation.validate(:secret, "")
       {:error, "secret must not be an empty binary string"}
 
@@ -106,6 +112,18 @@ defmodule AppIdentity.Validation do
 
   def validate(:padlock, value) when not is_binary(value) do
     {:error, "padlock must be a string value"}
+  end
+
+  def validate(:padlock, "") do
+    {:error, "padlock must not be an empty string"}
+  end
+
+  def validate(:padlock, value) do
+    if Regex.match?(~r/^[[:xdigit:]]+$/, value) do
+      {:ok, String.upcase(value)}
+    else
+      {:error, "padlock must be a hex string value"}
+    end
   end
 
   def validate(:nonce, value) when not is_binary(value) do

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -4,7 +4,7 @@ defmodule AppIdentity.MixProject do
   def project do
     [
       app: :app_identity,
-      version: "1.3.1",
+      version: "1.3.2",
       description: "Fast, lightweight, cryptographically secure app authentication",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,

--- a/elixir/support/support.ex
+++ b/elixir/support/support.ex
@@ -80,7 +80,7 @@ defmodule AppIdentity.Support do
 
     hash
     |> :crypto.hash(raw)
-    |> Base.encode16(case: :upper)
+    |> Base.encode16(case: Keyword.get(options, :case, :upper))
   end
 
   def build_proof(app, padlock, options \\ []) do

--- a/ruby/lib/app_identity/validation.rb
+++ b/ruby/lib/app_identity/validation.rb
@@ -63,7 +63,8 @@ class AppIdentity
         raise AppIdentity::Error, "padlock must be a string" unless padlock.is_a?(String)
         validate_not_empty(:padlock, padlock)
         validate_no_colons(:padlock, padlock)
-      }
+        raise AppIdentity::Error, "padlock must be a hex string" unless padlock.match?(/^[a-f0-9]+$/i)
+      }.upcase
     end
 
     private

--- a/ts/support/index.ts
+++ b/ts/support/index.ts
@@ -74,7 +74,10 @@ export const buildPadlock = (
 
   const hash = createHash(versionAlgorithm(version as number))
   hash.update(raw, 'utf-8')
-  return hash.digest('hex').toUpperCase()
+
+  return options['case'] === 'lower'
+    ? hash.digest('hex').toLowerCase()
+    : hash.digest('hex').toUpperCase()
 }
 
 export const buildProof = (

--- a/ts/support/matchers/index.ts
+++ b/ts/support/matchers/index.ts
@@ -4,7 +4,7 @@ import { App } from '../../src/app'
 
 interface AppIdentityMatchers<R = unknown> {
   // eslint-disable-next-line no-unused-vars
-  toBeVerified(expected: App): R
+  toBeVerified(expected: App | null): R
 }
 
 declare global {

--- a/ts/test/app_identity.test.ts
+++ b/ts/test/app_identity.test.ts
@@ -132,6 +132,34 @@ test('verify success v2 custom fuzz', () => {
   expect(verifyProofWithDiagnostic(proof, v2)).toBeVerified(app)
 })
 
+test('verify success v1 (lowercase proof)', () => {
+  const v1 = Support.v1Input()
+  const app = new App(v1)
+  const padlock = Support.buildPadlock(app, { case: 'lower' })
+  const proof = Support.buildProof(app, padlock)
+
+  expect(verifyProofWithDiagnostic(proof, v1)).toBeVerified(app)
+})
+
+test('verify success v2 default fuzz (lowercase proof)', () => {
+  const v2 = Support.v2Input()
+  const app = new App(v2)
+  const nonce = Support.timestampNonce(-6, 'minutes')
+  const padlock = Support.buildPadlock(app, { nonce })
+  const proof = Support.buildProof(app, padlock, { nonce, case: 'lower' })
+  expect(verifyProofWithDiagnostic(proof, v2)).toBeVerified(app)
+})
+
+test('verify success v2 custom fuzz (lowercase proof)', () => {
+  const v2 = Support.v2Input(300)
+  const app = new App(v2)
+  const nonce = Support.timestampNonce(-2, 'minutes')
+  const padlock = Support.buildPadlock(app, { nonce })
+  const proof = Support.buildProof(app, padlock, { nonce, case: 'lower' })
+
+  expect(verifyProofWithDiagnostic(proof, v2)).toBeVerified(app)
+})
+
 test('verify fail on different app ids', () => {
   const v1 = Support.v1Input()
   const app = new App(v1)


### PR DESCRIPTION
Resolved an issue where padlock values sent using lowercase hex values were not comparing properly. Added tests for the case as well as an additional validation doctest.

A later update will add this to the integration test suite as a variable.