### PR TITLE
Spec version 4.2

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -42,13 +42,13 @@ jobs:
           - elixir: '1.14'
             otp: '25'
             os: ubuntu-22.04
+          - elixir: '1.15'
+            otp: '26'
+            os: ubuntu-22.04
             check_formatted: true
             warnings_as_errors: true
             dialyzer: true
             credo: true
-          - elixir: '1.15'
-            otp: '26'
-            os: ubuntu-22.04
 
     runs-on: ${{ matrix.os }}
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,15 @@
 > - [Ruby](ruby/Changelog.md)
 > - [Typescript](ts/Changelog.md)
 
+## 4.2 / 2023-11-23
+
+- Reword several paragraphs for improved clarity.
+
+- Improved typographic consistency.
+
+- Reordered example code to show the Typescript versions _first_ as that is the
+  code sample which is likely to be most approachable.
+
 ## 4.1 / 2023-07-07
 
 - Security recommendations for the generation and in-memory use of application
@@ -16,3 +25,5 @@
 ## 4.0 / 2022-09-07
 
 - Initial public release as specification version 4.
+
+[rfc2119]: https://datatracker.ietf.org/doc/html/rfc2119

--- a/elixir/lib/app_identity/app.ex
+++ b/elixir/lib/app_identity/app.ex
@@ -45,7 +45,7 @@ defmodule AppIdentity.App do
   A 0-arity loader function that returns a map or struct that can be converted
   into an App struct.
   """
-  @type loader :: (() -> input | t | {:ok, input | t} | invalid_input)
+  @type loader :: (-> input | t | {:ok, input | t} | invalid_input)
 
   @typedoc """
   A finder function accepting a Proof struct parameter that returns a map or
@@ -66,7 +66,7 @@ defmodule AppIdentity.App do
   """
   @type t :: %__MODULE__{
           id: AppIdentity.id(),
-          secret: (() -> AppIdentity.secret()),
+          secret: (-> AppIdentity.secret()),
           version: AppIdentity.version(),
           config: config(),
           source: nil | term(),

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -50,32 +50,30 @@ defmodule AppIdentity.MixProject do
   end
 
   defp deps do
-    dialyxir =
-      if Version.compare(System.version(), "1.12.0") == :lt, do: "~> 1.3.0", else: "~> 1.4"
-
     poison =
       if Version.compare(System.version(), "1.11.0") == :lt,
         do: ">= 3.0.0 and < 6.0.0",
         else: ">= 3.0.0"
-
-    {ex_doc, extra} =
-      if Version.compare(System.version(), "1.11.0") == :lt do
-        {"~> 0.27.0", [{:earmark_parser, "1.4.19"}]}
-      else
-        {"~> 0.29", []}
-      end
 
     [
       {:jason, "~> 1.0", optional: true},
       {:plug, "~> 1.0", optional: true},
       {:poison, poison, optional: true},
       {:telemetry, "~> 0.4 or ~> 1.0", optional: true},
-      {:tesla, "~> 1.0", optional: true},
-      {:credo, "~> 1.0", only: [:dev], runtime: false},
-      {:dialyxir, dialyxir, only: [:dev], runtime: false},
-      {:ex_doc, ex_doc, only: [:dev], runtime: false},
-      {:secure_random, "~> 0.5", only: [:dev, :test]}
-    ] ++ extra
+      {:tesla, "~> 1.0", optional: true}
+    ] ++ dev_deps()
+  end
+
+  defp dev_deps do
+    if Version.compare(System.version(), "1.15.0") == :lt do
+      []
+    else
+      [
+        {:credo, "~> 1.0", only: [:dev], runtime: false},
+        {:dialyxir, "~> 1.4", only: [:dev], runtime: false},
+        {:ex_doc, "~> 0.29", only: [:dev], runtime: false}
+      ]
+    end
   end
 
   defp elixirc_paths(:test) do

--- a/elixir/support/app_identity/suite.ex
+++ b/elixir/support/app_identity/suite.ex
@@ -7,7 +7,7 @@ defmodule AppIdentity.Suite do
     @banner
   end
 
-  if function_exported?(Kernel, :is_exception, 1) do
+  if macro_exported?(Kernel, :is_exception, 1) do
     def extract_message(term) when is_exception(term) do
       Exception.message(term)
     end


### PR DESCRIPTION
Spec version 4.2

- Reword several paragraphs for improved clarity.

- Improved typographic consistency. **Bold** words are used exclusively for RFC2199 keywords. _Italic_ words are used for emphasis. `Code` words are used for core algorithmic concepts (`id`, `secret`, `padlock`, etc.).

- Reordered example code to show the Typescript versions _first_ as that is the variation most people will be familiar with.

Fix Elixir builds by removing purely development and release tooling from dependencies lower than the most recent supported version of Elixir (1.15).