### PR TITLE
chore: Elixir 1.18 breaks pipe tests

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -95,9 +95,16 @@ jobs:
       - run: mix test
         working-directory: ./elixir
 
-      - run: >
-          mix app_identity generate --stdout |
-          mix app_identity run --stdin --strict
+      # Switched to file-basd because the pipe approach has been broken for
+      # Elixir 1.18
+      #
+      # See https://github.com/elixir-lang/elixir/issues/14136
+      - run: |
+          # mix app_identity generate --stdout |
+          #   mix app_identity run --diagnostic --stdin --strict
+          mix app_identity generate
+          mix app_identity run --diagnostic --strict app-identity-suite-elixir.json
+          rm -f app-identity-suite-elixir.json
         working-directory: ./elixir
 
       - run: mix credo --strict

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -113,5 +113,5 @@ jobs:
 
       - run: >
           bundle exec bin/app-identity-suite-ruby generate --stdout |
-            bundle exec bin/app-identity-suite-ruby run --stdin --strict
+            bundle exec bin/app-identity-suite-ruby run --diagnostic --stdin --strict
         working-directory: ./ruby

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -56,5 +56,5 @@ jobs:
       - name: self-test
         run: |
           pnpm --silent cli:generate --stdout |
-            pnpm --silent cli:run --strict --stdin
+            pnpm --silent cli:run --diagnostic --strict --stdin
         working-directory: ./ts


### PR DESCRIPTION
Also add --diagnostic to language self-tests
