### PR TITLE
chore: Switch Elixir tests back to pipes

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -19,7 +19,7 @@ jobs:
       LC_CTYPE: en_US.UTF-8
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - elixir: '1.10'
@@ -95,17 +95,12 @@ jobs:
       - run: mix test
         working-directory: ./elixir
 
-      # Switched to file-basd because the pipe approach has been broken for
-      # Elixir 1.18
-      #
-      # See https://github.com/elixir-lang/elixir/issues/14136
       - run: |
-          # mix app_identity generate --stdout |
-          #   mix app_identity run --diagnostic --stdin --strict
-          mix app_identity generate
-          mix app_identity run --diagnostic --strict app-identity-suite-elixir.json
-          rm -f app-identity-suite-elixir.json
+          mix app_identity generate --stdout |
+            mix app_identity run --diagnostic --stdin --strict
         working-directory: ./elixir
+        env:
+          MIX_QUIET: 1
 
       - run: mix credo --strict
         working-directory: ./elixir

--- a/elixir/support/app_identity/suite/generator.ex
+++ b/elixir/support/app_identity/suite/generator.ex
@@ -79,9 +79,7 @@ defmodule AppIdentity.Suite.Generator do
     end
 
     if options[:stdout] do
-      suite
-      |> Jason.encode!(pretty: true)
-      |> shell.info()
+      IO.write(:stdio, Jason.encode!(suite, pretty: true))
     else
       File.write!(name, Jason.encode!(suite))
 


### PR DESCRIPTION
As part of elixir-lang/elixir#14136, I learned about MIX_QUIET, to suppress `Mix.shell()` output. Using this would not have worked with the generator, but the generator was using `Mix.shell.info/1` to output the JSON suite data. Changing that to `IO.write(:stdio, …)` means that we can use `MIX_QUIET=1` for our tests.

Running this manually with Elixir 1.18.0 will still fail unless `MIX_QUIET=1` is specified, but Elixir 1.18.1 or later will have this fixed because the lock warnings are written to stderr instead of stdout.