### PR TITLE
unified dependabot gha upgrades

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: KineticCafe/actions-dco@a7f6488b8cadf38f423990df5fb9305dc33835ea #v1.3.2
+      - uses: KineticCafe/actions-dco@416cafbc9c07f26219d09981d9ac49ce29b5bfea #v1.3.4
         with:
           exempt-authors: |
             @kineticcommerce.com

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: reviewdog/action-actionlint@abd537417cf4991e1ba8e21a67b1119f4f53b8e0 #v1.64.1
+      - uses: reviewdog/action-actionlint@a5524e1c19e62881d79c1f1b9b6f09f16356e281 #v1.65.2
 
   biome:
     if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: reviewdog/action-typos@2d77b519f5787ca723660c00f9bc82d61b63f5fe #v1.16.0
+      - uses: reviewdog/action-typos@e50daf62ea7a1c24960365c0f70f05296f25e1dc #v1.17.3
 
   actionlint:
     if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@dd746615b3b9d728a6a37ca2045b68ca76d4841a #v3.28.8
+        uses: github/codeql-action/upload-sarif@1b549b9259bda1cb5ddde3b41741a82a2d15a841 #v3.28.13
         with:
           sarif_file: results.sarif
           category: zizmor


### PR DESCRIPTION
- **deps: Bump KineticCafe/actions-dco from 1.3.2 to 1.3.4**
- **deps: Bump reviewdog/action-actionlint from 1.64.1 to 1.65.2**
- **deps: Bump github/codeql-action from 3.28.8 to 3.28.13**
- **deps: Bump reviewdog/action-typos from 1.16.0 to 1.17.3**
